### PR TITLE
feat: spring-boot-admin

### DIFF
--- a/applications/spring-boot-admin.libsonnet
+++ b/applications/spring-boot-admin.libsonnet
@@ -5,6 +5,7 @@ local k = import '../prelude.libsonnet';
     springBootAdmin: {
       name: 'spring-boot-admin',
       image: 'ghcr.io/cloudflightio/spring-boot-admin-docker:2.7.3',
+      host: error '$._config.springBootAdmin.host must be defined',
       serviceAccountName: 'default',
       config: {
         spring: {
@@ -63,5 +64,6 @@ local k = import '../prelude.libsonnet';
                   volume.fromConfigMap('config', self.config.metadata.name),
                 ]),
     service: k.util.serviceFor(self.deployment),
+    ingress: k.util.ingressFor(self.service, $._config.springBootAdmin.host),
   },
 }

--- a/applications/spring-boot-admin.libsonnet
+++ b/applications/spring-boot-admin.libsonnet
@@ -1,0 +1,67 @@
+local k = import '../prelude.libsonnet';
+{
+  _config+:: {
+    // begin_config
+    springBootAdmin: {
+      name: 'spring-boot-admin',
+      image: 'ghcr.io/cloudflightio/spring-boot-admin-docker:2.7.3',
+      serviceAccountName: 'default',
+      config: {
+        spring: {
+          cloud: {
+            kubernetes: {
+              discovery: {
+                enabled: true,
+                'service-labels': {
+                  '[app.openshift.io/runtime]': 'spring-boot',
+                },
+                catalogServiceWatchDelay: 300,
+                'primary-port-name': 'actuator',
+              },
+            },
+          },
+        },
+      },
+      resources:: {
+        limits: {
+          cpu: '500m',
+          memory: '512Mi',
+        },
+        requests: {
+          cpu: '10m',
+          memory: '512Mi',
+        },
+      },
+    },
+    // end_config
+  },
+  springBootAdmin: {
+    local deployment = k.apps.v1.deployment,
+    local container = k.core.v1.container,
+    local port = k.core.v1.containerPort,
+    local volumeMount = k.core.v1.volumeMount,
+    local volume = k.core.v1.volume,
+    local secret = k.core.v1.secret,
+    local cm = k.core.v1.configMap,
+    local pvc = k.core.v1.persistentVolumeClaim,
+    local is = k.image.v1.imageStream,
+    config: cm.new($._config.springBootAdmin.name, data={
+      'application.yaml': std.manifestYamlDoc($._config.springBootAdmin.config),
+    }),
+
+    deployment: deployment.new(name=$._config.springBootAdmin.name, replicas=1, containers=[
+                  k.util.java.container.new(name='spring-boot-admin', image=$._config.springBootAdmin.image, actuatorPort=8080)
+                  + container.withVolumeMounts([
+                    volumeMount.new(name='config', mountPath='/deployments/application.yaml')
+                    + volumeMount.withSubPath('application.yaml'),
+                  ])
+                  + container.resources.withRequests($._config.springBootAdmin.resources.requests)
+                  + container.resources.withLimits($._config.springBootAdmin.resources.limits),
+                ])
+                + deployment.spec.template.spec.withServiceAccountName($._config.springBootAdmin.serviceAccountName)
+                + deployment.spec.template.spec.withVolumes([
+                  volume.fromConfigMap('config', self.config.metadata.name),
+                ]),
+    service: k.util.serviceFor(self.deployment),
+  },
+}

--- a/docs/modules/applications/spring-boot-admin.md
+++ b/docs/modules/applications/spring-boot-admin.md
@@ -1,0 +1,28 @@
+# Spring Boot Admin
+
+This module creates an instance of
+[spring-boot-admin](https://github.com/codecentric/spring-boot-admin),
+preconfigured to discover endpoints via Kubernetes.
+
+The following snippets lists all available configuration options alongside their default values:
+
+```.ts
+(import 'cloudflight-libsonnet/applications/spring-boot-admin.libsonnet')
++ {
+  _config+: {
+    {%
+      include "../../../applications/spring-boot-admin.libsonnet"
+      start="// begin_config\n"
+      end="// end_config\n"
+    %}
+  }
+}
+```
+
+## Integration and Service Discovery
+
+When using our [java helpers](../java_applications.md), spring-boot-admin will
+automatically discover provided services and their respective actuator
+endpoints.
+
+To customize the discovery, modify `$._config.springBootAdmin.config.spring.cloud.kubernetes.discovery` to match your labels.

--- a/tests/environments/test-spring-boot-admin/main.jsonnet
+++ b/tests/environments/test-spring-boot-admin/main.jsonnet
@@ -2,6 +2,9 @@
 + (import 'cloudflight-libsonnet/applications/spring-boot-admin.libsonnet')
 + {
   _config+: {
+    springBootAdmin+: {
+      host: 'sba.internal.cloudflight.dev',
+    },
     myApplication+: {
       image: 'spring-boot-hello-world',
     },

--- a/tests/environments/test-spring-boot-admin/main.jsonnet
+++ b/tests/environments/test-spring-boot-admin/main.jsonnet
@@ -1,0 +1,9 @@
+(import 'test-java.libsonnet')
++ (import 'cloudflight-libsonnet/applications/spring-boot-admin.libsonnet')
++ {
+  _config+: {
+    myApplication+: {
+      image: 'spring-boot-hello-world',
+    },
+  },
+}

--- a/tests/environments/test-spring-boot-admin/spec.json
+++ b/tests/environments/test-spring-boot-admin/spec.json
@@ -1,0 +1,13 @@
+{
+  "apiVersion": "tanka.dev/v1alpha1",
+  "kind": "Environment",
+  "metadata": {
+    "name": "environments/test-spring-boot-admin"
+  },
+  "spec": {
+    "apiServer": "https://openshift-dev.internal.cloudflight.io:6443",
+    "namespace": "webner",
+    "resourceDefaults": {},
+    "expectVersions": {}
+  }
+}

--- a/tests/environments/test-spring-boot-admin/test-java.libsonnet
+++ b/tests/environments/test-spring-boot-admin/test-java.libsonnet
@@ -1,0 +1,17 @@
+local k = (import 'cloudflight-libsonnet/prelude.libsonnet');
+{
+  _config+:: {
+    myApplication: {
+      name: 'my-application',
+      image: error '$._config.myApplication.image must be defined',
+    },
+  },
+  myApplication: {
+    deployment: k.util.java.deployment.new(
+      name=$._config.myApplication.name,
+      image=$._config.myApplication.image
+    ),
+    service: k.util.serviceFor(self.deployment),
+    route: k.util.routeFor(self.service, 'hello.example.com'),
+  },
+}

--- a/util/java.libsonnet
+++ b/util/java.libsonnet
@@ -53,7 +53,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
           env={}
         ): container.new(name, image)
            + container.withPorts([
-             p.new('http', 8080),
+             p.new('http', port),
              p.new('actuator', actuatorPort),
            ])
            + container.withEnvMap({
@@ -69,7 +69,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
              memory: '1Gi',
            })
            + k.util.java.livenessProbe.new()
-           + k.util.java.readinessProbe.new(),
+           + k.util.java.readinessProbe.new(actuatorPort),
 
       },
       deployment+: {

--- a/util/java.libsonnet
+++ b/util/java.libsonnet
@@ -49,7 +49,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
           name,
           image,
           port=8080,
-          actuatorPort=port + 1000,
+          actuatorPort=port + 10000,
           env={}
         ): container.new(name, image)
            + container.withPorts([
@@ -76,11 +76,25 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
         local deployment = k.apps.v1.deployment,
         '#new': d.fn(|||
           constructs a deployment using the java container. If you need more control, construct this deployment yourself.
-        |||, [d.arg('name', d.T.string), d.arg('image', d.T.string), d.arg('replicas', d.T.number, 1), d.arg('env', d.T.object, {})]),
-        new(name, image, replicas=1, env={}):
+
+          The `runtime` and `component` parameters are used to prefill reccomended labels
+        |||, [
+          d.arg('name', d.T.string),
+          d.arg('image', d.T.string),
+          d.arg('replicas', d.T.number, 1),
+          d.arg('env', d.T.object, {}),
+          d.arg('runtime', d.T.string, 'spring-boot'),
+          d.arg('component', d.T.string, 'backend'),
+        ]),
+        new(name, image, replicas=1, env={}, runtime='spring-boot', component='backend'):
           deployment.new(name, replicas, containers=[
             k.util.java.container.new(name, image, port=8080, env=env),
-          ]),
+          ])
+          + deployment.metadata.withLabelsMixin({
+            'app.openshift.io/runtime': runtime,
+            'app.kubernetes.io/name': name,
+            'app.kubernetes.io/component': component,
+          }),
       },
     },
   },

--- a/util/main.libsonnet
+++ b/util/main.libsonnet
@@ -3,6 +3,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
   withK(k)::
     (import 'java.libsonnet').withK(k)
     + (import 'route.libsonnet').withK(k)
+    + (import 'service.libsonnet').withK(k)
     + {
       '#': d.pkg(
         name='util',

--- a/util/route.libsonnet
+++ b/util/route.libsonnet
@@ -7,8 +7,8 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
       a value for the hostname and defaults to '/' for the path.
     |||, [
       d.arg('service', d.T.object),
-      d.arg('port', d.T.number, 18080),
-      d.arg('path', d.T.string, '/actuator/health'),
+      d.arg('port', d.T.number, ''),
+      d.arg('path', d.T.string, '/'),
       d.arg('port', d.T.number, 'service.spec.ports[0].port'),
     ]),
     routeFor(service, host, path='/', port=service.spec.ports[0].port)::

--- a/util/route.libsonnet
+++ b/util/route.libsonnet
@@ -16,5 +16,34 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
       + route.spec.to.withKind('Service')
       + route.spec.to.withName(service.metadata.name)
       + route.spec.port.withTargetPort(port),
+
+    local ingress = k.networking.v1.ingress,
+    local rule = k.networking.v1.ingressRule,
+    local hpath = k.networking.v1.httpIngressPath,
+    '#ingressFor': d.fn(|||
+      ingressFor constructs a ingress object, compatible with the automatic
+      translation to openshift routes. It expects a value for the hostname and
+      defaults to '/' for the path.
+    |||, [
+      d.arg('service', d.T.object),
+      d.arg('port', d.T.number, ''),
+      d.arg('path', d.T.string, '/'),
+      d.arg('port', d.T.number, 'service.spec.ports[0].port'),
+    ]),
+    ingressFor(service, host, path='/', port=service.spec.ports[0].port)::
+      ingress.new(service.metadata.name)
+      + ingress.metadata.withAnnotationsMixin({
+        'route.openshift.io/termination': 'edge',
+      })
+      + ingress.spec.withRules(
+        rule.withHost(host)
+        + rule.http.withPaths([
+          hpath.withPath(path)
+          + hpath.withPathType('Prefix')
+          + hpath.backend.service.withName(service.metadata.name)
+          + hpath.backend.service.port.withNumber(port),
+        ])
+      ),
+
   },
 }

--- a/util/service.libsonnet
+++ b/util/service.libsonnet
@@ -1,0 +1,25 @@
+local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+{
+  withK(k):: {
+    local service = k.core.v1.service,
+    '#serviceFor': d.fn(|||
+
+      serviceFor constructs a service for the specified deployment.
+
+      Selector labels are taken from the pod spec but can be ignored using the
+      `ignored_labels` parameter.
+
+      The ports of the service will have the same name as in the container spec
+      to avoid confusion. This can be changed with the `nameFormat` parameter.
+    |||, [
+      d.arg('deployment', d.T.object),
+      d.arg('ignored_labels', d.T.array),
+      d.arg('nameFormat', d.T.string, '%(port)s'),
+    ]),
+    serviceFor(deployment, ignored_labels=[], nameFormat='%(port)s')::
+      super.serviceFor(deployment, ignored_labels, nameFormat)
+      + service.metadata.withLabelsMixin(
+        if (std.objectHas(deployment.metadata, 'labels')) then deployment.metadata.labels else {},
+      ),
+  },
+}


### PR DESCRIPTION
This adds support for spring-boot-admin, based on [spring-boot-admin-docker](https://github.com/cloudflightio/spring-boot-admin-docker).
It also enhances the java library to add more labels and introduces a needed ingress utility function